### PR TITLE
need perf go.mod to make go.work valid

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,6 +19,7 @@ doc-site/
 domains/zeto/zkp
 # perf is not needed
 perf/
+!perf/go.mod
 
 # The operator has its own docker build (with its own .dockerignore), so we don't want to rebuild the whole
 # Paladin docker every time you're re-running the operator/test.

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,6 +126,7 @@ COPY toolkit/java toolkit/java
 COPY domains/pente domains/pente
 COPY domains/zeto domains/zeto
 COPY domains/noto domains/noto
+COPY perf/go.mod perf/go.mod
 COPY domains/integration-test domains/integration-test
 COPY registries/static registries/static
 COPY registries/evm registries/evm


### PR DESCRIPTION
CI build is failing - https://github.com/LF-Decentralized-Trust-labs/paladin/actions/runs/12985190272/job/36214574383?pr=535

because we trip over an invalid go.work file while executing `go list -f {{.Dir}} github.com/kaleido-io/paladin/toolkit/pkg/rpcclient` here https://github.com/annamcallister/paladin/blob/perf/core/go/build.gradle#L168

go.work is invalid because it mentions `perf` but there is no module for `perf` in the docker layer.